### PR TITLE
Added slf4j-jul-to-slf4j bridge which allows logs from java.util.logg…

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -21,9 +21,10 @@ repositories {
 dependencies {
     api(libs.kotlin.stdlib)
     api(libs.kotlinx.coroutines.core.jvm)
-    api(libs.okhttp)
 
+    implementation(libs.okhttp)
     implementation(libs.slf4j.api)
+    implementation(libs.slf4j.jul.to.slf4j)
     implementation(libs.moshi)
     implementation(libs.jsonpathkt)
     implementation(libs.jsoup)

--- a/core/src/main/kotlin/io/github/manamiproject/modb/core/logging/Slf4jLogger.kt
+++ b/core/src/main/kotlin/io/github/manamiproject/modb/core/logging/Slf4jLogger.kt
@@ -1,12 +1,17 @@
 package io.github.manamiproject.modb.core.logging
 
 import org.slf4j.LoggerFactory
+import org.slf4j.bridge.SLF4JBridgeHandler
 import kotlin.reflect.KClass
 
 internal class Slf4jLogger(
     ref: KClass<*>,
     private val slf4jLogger: org.slf4j.Logger = LoggerFactory.getLogger(ref.java),
 ): Logger {
+
+    init {
+        SLF4JBridgeHandler.install()
+    }
 
     override fun error(message: () -> String) = slf4jLogger.error(message.invoke())
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ slf4j-api = "2.0.17"
 tomlj = "1.1.1"
 wiremock = "3.13.1"
 zstandard = "1.5.7-3"
+slf4j-jul-to-slf4j = "2.0.17"
 
 
 [libraries]
@@ -35,6 +36,7 @@ logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "lo
 moshi = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j-api" }
+slf4j-jul-to-slf4j = { module = "org.slf4j:jul-to-slf4j", version.ref = "slf4j-jul-to-slf4j" }
 tomlj = { module = "org.tomlj:tomlj", version.ref = "tomlj" }
 wiremock = { module = "org.wiremock:wiremock", version.ref = "wiremock" }
 zstandard = { module = "com.github.luben:zstd-jni", version.ref = "zstandard" }


### PR DESCRIPTION
…ing to be picked up by ModbLogger which uses SLF4j underneath

This is important for OkHttpClient, because those logs were shown in stdout, but haven't been written to the log files.